### PR TITLE
Add ucmatose, ucx_perftest tests and fix rping/vnic tests

### DIFF
--- a/examples/oracle/oracle-cluster-demo.py
+++ b/examples/oracle/oracle-cluster-demo.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# This file is part of pycloudlib. See LICENSE file for license information.
+"""Basic examples of various lifecycle with an OCI instance."""
+
+import logging
+import sys
+
+import pycloudlib
+
+def demo_cluster(
+    availability_domain: str = None,
+    compartment_id: str = None,
+    vcn_name: str = None,
+):
+    """Show example of using the OCI library to launch a cluster instance and ping between them."""
+
+    with pycloudlib.OCI(
+        "pycl-oracle-cluster-demo",
+        availability_domain=availability_domain,
+        compartment_id=compartment_id,
+        vcn_name=vcn_name,
+    ) as client:
+        instances = client.create_compute_cluster(
+            image_id=client.released_image("noble"),
+            instance_count=2,
+        )
+        # get the private ips of the instances
+        private_ips = [instance.private_ip for instance in instances]
+        # try to ping each instance from each other instance at their private ip
+        for instance in instances:
+            for private_ip in private_ips:
+                if private_ip != instance.private_ip:
+                    print(f"Pinging {private_ip} from {instance.private_ip}")
+                    r = instance.execute(f"ping -c 1 -W 5 {private_ip}")
+                    if not r.ok:
+                        print(f"Failed to ping {private_ip} from {instance.private_ip}")
+                    else:
+                        print(f"Successfully pinged {private_ip} from {instance.private_ip}")
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    if len(sys.argv) != 3:
+        print(
+            "No arguments passed via command line. "
+            "Assuming values are set in pycloudlib configuration file."
+        )
+        demo_cluster()
+    else:
+        passed_availability_domain = sys.argv[1]
+        passed_compartment_id = sys.argv[2]
+        passed_vcn_name = sys.argv[3] if len(sys.argv) == 4 else None
+        demo_cluster(passed_availability_domain, passed_compartment_id, passed_vcn_name)

--- a/examples/oracle/oracle-example-cluster-test.py
+++ b/examples/oracle/oracle-example-cluster-test.py
@@ -113,7 +113,7 @@ class TestOracleClusterMofed:
                 subnet_name="private subnet-mofed-vcn", # use the private subnet for mofed testing
             )
             time.sleep(30) # wait for the secondary vnic to be attached
-            instance.configure_secondary_vnic(instance)
+            instance.configure_secondary_vnic()
             setup_mofed_iptables_rules(instance)
             
         yield cluster

--- a/examples/oracle/oracle-example-cluster-test.py
+++ b/examples/oracle/oracle-example-cluster-test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# This file is part of pycloudlib. See LICENSE file for license information.
+"""Basic examples of various lifecycle with an OCI instance."""
+
+from datetime import datetime
+import json
+import logging
+import sys
+import time
+
+import pytest
+
+import pycloudlib
+from pycloudlib.oci.instance import OciInstance
+from typing import Generator
+import logging
+
+logger = logging.getLogger(__name__)
+
+EXISTING_INSTANCE_IDS = [
+    # add the OCIDs of the instances you want to use for testing here
+]
+
+# change this to either "class" or "module" as you see fit
+@pytest.fixture(scope="module")
+def cluster() -> Generator[list[OciInstance], None, None]:
+    """
+    Launch a cluster of BM instances and yield them.
+    """ 
+
+    with pycloudlib.OCI(
+        "pycl-oracle-cluster-test",
+        # use the already created "mofed-vcn" for cluster testing
+        vcn_name="mofed-vcn" # THIS WILL OVERRIDE THE VCN_NAME IN THE CONFIG FILE
+    ) as client:
+        if EXISTING_INSTANCE_IDS:
+            instances = [client.get_instance(instance_id) for instance_id in EXISTING_INSTANCE_IDS]
+            yield instances
+        else:
+            # create_compute_cluster already calls wait() on the instances
+            # so once this function returns, the instances are ready
+            instances = client.create_compute_cluster(
+                # if you create a custom image, specify its OCID here
+                image_id=client.released_image("noble"), 
+                instance_count=2,
+            )
+            yield instances
+
+
+class TestOracleClusterBasic:
+    def test_basic_ping_on_private_ips(self, cluster: list[OciInstance]):
+        # get the private ips of the instances
+        private_ips = [instance.private_ip for instance in cluster]
+        # try to ping each instance from each other instance at their private ip
+        for instance in cluster:
+            for private_ip in private_ips:
+                if private_ip != instance.private_ip:
+                    logger.info(f"Pinging {private_ip} from {instance.private_ip}")
+                    # ping once with a timeout of 5 seconds
+                    r = instance.execute(f"ping -c 1 -W 5 {private_ip}")
+                    assert r.ok, f"Failed to ping {private_ip} from {instance.private_ip}"
+                    logger.info(f"Successfully pinged {private_ip} from {instance.private_ip}")
+
+def setup_mofed_iptables_rules(instance: OciInstance):
+    # Update the cloud.cfg file to set preserve_hostname to true
+    instance.execute("sed -i 's/preserve_hostname: false/preserve_hostname: true/' /etc/cloud/cloud.cfg")
+    # Backup the existing iptables rules
+    backup_file = f"/etc/iptables/rules.v4.bak.{datetime.now().strftime('%F-%T')}"
+    instance.execute(f"cp -v /etc/iptables/rules.v4 {backup_file}")
+    # Overwrite the iptables rules with the new configuration
+    rules = """
+    *filter
+    :INPUT ACCEPT [0:0]
+    :FORWARD ACCEPT [0:0]
+    :OUTPUT ACCEPT [0:0]
+
+    # Allow all traffic on ens300f1np1 and ens800f0np0
+    -A INPUT -i ens300f1np1 -j ACCEPT
+    -A OUTPUT -o ens300f1np1 -j ACCEPT
+    -A INPUT -i ens800f0np0 -j ACCEPT
+    -A OUTPUT -o ens800f0np0 -j ACCEPT
+
+    # Re-add REJECT rule for ens300f0np0
+    -A INPUT -i ens300f0np0 -p icmp -j REJECT --reject-with icmp-host-prohibited
+    -A OUTPUT -o ens300f0np0 -p icmp -j REJECT --reject-with icmp-host-prohibited
+
+    COMMIT
+    """
+    instance.execute(f"cat > /etc/iptables/rules.v4 << 'EOL' {rules} EOL")
+    # Restore the new iptables rules
+    instance.execute("iptables-restore < /etc/iptables/rules.v4")
+    # Log the current iptables rules with line numbers
+    iptables_out = instance.execute("iptables -L -v -n --line-numbers")
+    logger.info("iptables rules: %s", iptables_out.stdout)
+    return instance
+
+
+
+class TestOracleClusterMofed:
+    @pytest.fixture(scope="class")
+    def mofed_cluster(self, cluster: list[OciInstance]) -> Generator[list[OciInstance], None, None]:
+        for instance in cluster:
+            if instance.secondary_vnic_private_ip:
+                logger.info(
+                    "Instance %s already has a secondary VNIC, not attaching one.", instance.name
+                )
+                continue
+            logger.info("Creating a secondary VNIC on instance %s", instance.name)
+            # create a secondary VNIC on the 2nd vnic on the private subnet for RDMA usage
+            new_private_ip = instance.add_network_interface(
+                nic_index=1,
+                subnet_name="private subnet-mofed-vcn", # use the private subnet for mofed testing
+            )
+            time.sleep(30) # wait for the secondary vnic to be attached
+            instance.configure_secondary_vnic(instance)
+            setup_mofed_iptables_rules(instance)
+            
+        yield cluster
+    
+    def test_basic_ping_on_new_rdma_ips(
+        self,
+        mofed_cluster: list[OciInstance],
+    ):
+        # get the private ips of the instances
+        rdma_ips = [instance.secondary_vnic_private_ip for instance in mofed_cluster]
+        # try to ping each instance from each other instance at their private ip
+        for instance in mofed_cluster:
+            for rdma_ip in rdma_ips:
+                if rdma_ip != instance.secondary_vnic_private_ip:
+                    logger.info(f"Pinging {rdma_ip} from {instance.secondary_vnic_private_ip}")
+                    # ping once with a timeout of 5 seconds
+                    r = instance.execute(f"ping -c 1 -W 5 {rdma_ip}")
+                    assert r.ok, f"Failed to ping {rdma_ip} from {instance.secondary_vnic_private_ip}"
+                    logger.info(f"Successfully pinged {rdma_ip} from {instance.secondary_vnic_private_ip}")
+            
+    def test_rping(
+        self,
+        mofed_cluster: list[OciInstance],
+    ):
+        server_instance = mofed_cluster[0]
+        client_instance = mofed_cluster[1]
+
+        # start the rping server on the first instance
+        server_instance.execute(f"rping -s -a {server_instance.secondary_vnic_private_ip} -v &")
+        # start the rping client on the second instance (only send 10 packets so it doesn't hang)
+        r = client_instance.execute(f"rping -c -a {server_instance.secondary_vnic_private_ip} -C 10 -v")
+        logger.info("rping output: %s", r.stdout)
+        assert r.ok, "Failed to run rping"
+
+
+

--- a/examples/oracle/oracle-example-cluster-test.py
+++ b/examples/oracle/oracle-example-cluster-test.py
@@ -14,6 +14,7 @@ import pycloudlib
 from pycloudlib.oci.instance import OciInstance
 from typing import Generator
 import logging
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -140,12 +141,84 @@ class TestOracleClusterMofed:
         server_instance = mofed_cluster[0]
         client_instance = mofed_cluster[1]
 
-        # start the rping server on the first instance
-        server_instance.execute(f"rping -s -a {server_instance.secondary_vnic_private_ip} -v &")
+        def start_server():
+            # start the rping server on the first instance
+            server_instance.execute(f"rping -s -a {server_instance.secondary_vnic_private_ip} -v &")
+
+        server_thread = threading.Thread(target=start_server)
+        server_thread.start()
+
+        # Wait for rping server to start
+        time.sleep(5)
         # start the rping client on the second instance (only send 10 packets so it doesn't hang)
         r = client_instance.execute(f"rping -c -a {server_instance.secondary_vnic_private_ip} -C 10 -v")
         logger.info("rping output: %s", r.stdout)
         assert r.ok, "Failed to run rping"
 
+    def test_ucmatose(
+        self,
+        mofed_cluster: list[OciInstance],
+    ):
+        server_instance = mofed_cluster[0]
+        client_instance = mofed_cluster[1]
+
+        def start_server():
+            # start the rping server on the first instance
+            server_instance.execute(f"ucmatose &")
+
+        server_thread = threading.Thread(target=start_server)
+        server_thread.start()
+
+        # Wait for server to start
+        time.sleep(5)
+        # start the client on the second instance (only send 10 packets so it doesn't hang)
+        r = client_instance.execute(f"ucmatose -s {server_instance.secondary_vnic_private_ip}")
+        logger.info("ucmatose output: %s", r.stdout)
+        assert r.ok, "Failed to run ucmatose"
+
+    def test_ucx_perftest_lat_one_node(
+        self,
+        mofed_cluster: list[OciInstance],
+    ):
+        server_instance = mofed_cluster[0]
+        # ucx_perftest only works within a single instance on all MOFED stacks right now, so this
+        # being 0 is intentional. (Will adjust if Oracle provides config info to resolve this)
+        client_instance = mofed_cluster[0]
+
+        def start_server():
+            # start the rping server on the first instance
+            server_instance.execute(f"ucx_perftest -c 0 &")
+
+        server_thread = threading.Thread(target=start_server)
+        server_thread.start()
+
+        # Wait for server to start
+        time.sleep(5)
+        # start the client on the second instance (only send 10 packets so it doesn't hang)
+        r = client_instance.execute(f"ucx_perftest {server_instance.secondary_vnic_private_ip} -t tag_lat -c 1")
+        logger.info("ucx_perftest output: %s", r.stdout)
+        assert r.ok, "Failed to run ucx_perftest"
 
 
+    def test_ucx_perftest_bw_one_node(
+        self,
+        mofed_cluster: list[OciInstance],
+    ):
+        server_instance = mofed_cluster[0]
+        # ucx_perftest only works within a single instance on all MOFED stacks right now, so this
+        # being 0 is intentional. (Will adjust if Oracle provides config info to resolve this)
+        client_instance = mofed_cluster[0]
+
+        def start_server():
+            # start the rping server on the first instance
+            server_instance.execute(f"ucx_perftest -c 0 &")
+
+        server_thread = threading.Thread(target=start_server)
+        server_thread.start()
+
+        # Wait for server to start
+        time.sleep(5)
+        # start the client on the second instance (only send 10 packets so it doesn't hang)
+        r = client_instance.execute(f"ucx_perftest {server_instance.secondary_vnic_private_ip} -t tag_bw -c 1")
+        logger.info("ucx_perftest output: %s", r.stdout)
+        assert r.ok, "Failed to run ucx_perftest"

--- a/pycloudlib/oci/instance.py
+++ b/pycloudlib/oci/instance.py
@@ -2,7 +2,9 @@
 # This file is part of pycloudlib. See LICENSE file for license information.
 """OCI instance."""
 
+import json
 from time import sleep
+import time
 from typing import Dict, List, Optional
 
 import oci
@@ -327,3 +329,46 @@ class OciInstance(BaseInstance):
                     )
                 return
         raise PycloudlibError(f"Network interface with ip_address={ip_address} did not detach")
+
+    def configure_secondary_vnic(self) -> str:
+        if not self.secondary_vnic_private_ip:
+            raise ValueError("Cannot configure secondary VNIC without a secondary VNIC attached")
+        secondary_vnic_imds_data: Optional[Dict[str, str]] = None
+        # it can take a bit for the 
+        for _ in range(60):
+            # Fetch JSON data from the Oracle Cloud metadata service
+            imds_req = self.execute("curl -s http://169.254.169.254/opc/v1/vnics").stdout
+            vnics_data = json.loads(imds_req)
+            if len(vnics_data) > 1:
+                self._log.debug("Successfully fetched secondary VNIC data from IMDS")
+                secondary_vnic_imds_data = vnics_data[1]
+                break
+            self._log.debug("No secondary VNIC data found from IMDS, retrying...")
+            time.sleep(1)
+
+        if not secondary_vnic_imds_data:
+            raise PycloudlibError(
+                "Failed to fetch secondary VNIC data from IMDS. Cannot configure secondary VNIC"
+            )
+                      
+        # Extract MAC address and private IP from the second VNIC 
+        mac_addr = secondary_vnic_imds_data["macAddr"]
+        private_ip = secondary_vnic_imds_data["privateIp"]
+        subnet_mask = secondary_vnic_imds_data["subnetCidrBlock"].split("/")[1]
+        # Find the network interface corresponding to the MAC address
+        interface = self.execute(
+            f"ip link show | grep -B1 {mac_addr} | head -n1 | awk '{{print $2}}' | sed 's/://' "
+        ).stdout.strip()
+        # Check if the interface was found
+        if not interface:
+            raise ValueError(f"No interface found for MAC address {mac_addr}")
+        # Add the IP address to the interface
+        self.execute(
+            f"sudo ip addr add {private_ip}/{subnet_mask} dev {interface}"
+        )
+        # Verify that the IP address was added
+        r = self.execute(f"ip addr show dev {interface}")
+        if private_ip not in r.stdout:
+            raise ValueError(f"IP {private_ip} was not successfully assigned to interface {interface}")
+        self._log.info("Successfully assigned IP %s to interface %s", private_ip, interface)
+        return private_ip

--- a/pycloudlib/oci/instance.py
+++ b/pycloudlib/oci/instance.py
@@ -9,7 +9,7 @@ import oci
 
 from pycloudlib.errors import PycloudlibError
 from pycloudlib.instance import BaseInstance
-from pycloudlib.oci.utils import get_subnet_id, wait_till_ready
+from pycloudlib.oci.utils import get_subnet_id, get_subnet_id_by_name, wait_till_ready
 
 
 class OciInstance(BaseInstance):
@@ -68,15 +68,24 @@ class OciInstance(BaseInstance):
     def name(self):
         """Return the instance name."""
         return self.instance_id
-
+    
     @property
     def ip(self):
         """Return IP address of instance."""
         if not self._ip:
-            vnic_attachment = self.compute_client.list_vnic_attachments(
-                compartment_id=self.compartment_id,
-                instance_id=self.instance_data.id,
-            ).data
+            for _ in range(100):
+                vnic_attachment = self.compute_client.list_vnic_attachments(
+                    compartment_id=self.compartment_id,
+                    instance_id=self.instance_data.id,
+                ).data
+                if vnic_attachment:
+                    break
+                self._log.debug("No vnic_attachment found, retrying...")
+                sleep(5)
+            else:
+                raise PycloudlibError("No vnic_attachment found after 100 retries")
+
+            self._log.debug("vnic_attachment: %s", vnic_attachment)
             vnics = [
                 self.network_client.get_vnic(vnic_attachment.vnic_id).data
                 for vnic_attachment in vnic_attachment
@@ -96,6 +105,48 @@ class OciInstance(BaseInstance):
                 self._log.info("Using ipv4 address: %s", self._ip)
             return self._ip
         return self._ip
+
+    @property
+    def private_ip(self):
+        """Return private IP address of instance."""
+        for _ in range(100):
+            vnic_attachment = self.compute_client.list_vnic_attachments(
+                compartment_id=self.compartment_id,
+                instance_id=self.instance_data.id,
+            ).data
+            if vnic_attachment:
+                break
+            self._log.debug("No vnic_attachment found, retrying...")
+            sleep(5)
+        else:
+            raise PycloudlibError("No vnic_attachment found after 100 retries")
+
+        self._log.debug("vnic_attachment: %s", vnic_attachment)
+        vnics = [
+            self.network_client.get_vnic(vnic_attachment.vnic_id).data
+            for vnic_attachment in vnic_attachment
+        ]
+        self._log.debug("vnics: %s", vnics)
+        # select vnic with is_primary = True
+        primary_vnic = [vnic for vnic in vnics if vnic.is_primary][0]
+        return primary_vnic.private_ip
+
+    @property
+    def secondary_vnic_private_ip(self) -> Optional[str]:
+        """Return private IP address of secondary vnic."""
+        vnic_attachments = self.compute_client.list_vnic_attachments(
+            compartment_id=self.compartment_id,
+            instance_id=self.instance_data.id,
+        ).data
+        if len(vnic_attachments) < 2:
+            return None
+        vnics = [
+            self.network_client.get_vnic(vnic_attachment.vnic_id).data
+            for vnic_attachment in vnic_attachments
+        ]
+        # get vnic that is not primary
+        secondary_vnic_attachment = [vnic for vnic in vnics if not vnic.is_primary][0]
+        return secondary_vnic_attachment.private_ip
 
     @property
     def instance_data(self):
@@ -195,25 +246,51 @@ class OciInstance(BaseInstance):
             func_kwargs=func_kwargs,
         )
 
-    def add_network_interface(self, **kwargs) -> str:
+    def get_secondary_vnic_ip(self) -> str:
+        """Check if the instance has a secondary VNIC."""
+        vnic_attachments = oci.pagination.list_call_get_all_results_generator(  # noqa: E501
+            self.compute_client.list_vnic_attachments,
+            "record",
+            self.compartment_id,
+            instance_id=self.instance_id,
+        )
+        return vnic_attachments[1].data.private_ip
+
+    def add_network_interface(
+        self,
+        nic_index: int = 0,
+        use_private_subnet: bool = False,
+        subnet_name: Optional[str] = None,
+    ) -> str:
         """Add network interface to running instance.
 
         Creates a nic and attaches it to the instance. This is effectively a
-        hot-add of a network device. Returns the IP address of the added
+        hot-add of a network device. Returns the private IP address of the added
         network interface as a string.
 
-        Note: It assumes the associated compartment has at least one subnet and
-        creates the vnic in the first encountered subnet.
+        Args:
+            nic_index: The index of the NIC to add
+            subnet_name: Name of the subnet to add the NIC to. If not provided,
+                will use `use_private_subnet` to select first available subnet.
+            use_private_subnet: If True, will select the first available private
+                subnet. If False, will select the first available public subnet.
+                This is only used if `subnet_name` is not provided.
         """
-        subnet_id = get_subnet_id(
-            self.network_client, self.compartment_id, self.availability_domain
-        )
+        if subnet_name:
+            subnet_id = get_subnet_id_by_name(
+                self.network_client, self.compartment_id, subnet_name,
+            )
+        else:
+            subnet_id = get_subnet_id(
+                self.network_client, self.compartment_id, self.availability_domain, private=use_private_subnet,
+            )
         create_vnic_details = oci.core.models.CreateVnicDetails(  # noqa: E501
             subnet_id=subnet_id,
         )
         attach_vnic_details = oci.core.models.AttachVnicDetails(  # noqa: E501
             create_vnic_details=create_vnic_details,
             instance_id=self.instance_id,
+            nic_index=nic_index,
         )
         vnic_attachment_data = self.compute_client.attach_vnic(attach_vnic_details).data
         vnic_attachment_data = wait_till_ready(

--- a/tests/integration_tests/oracle/test_cluster.py
+++ b/tests/integration_tests/oracle/test_cluster.py
@@ -1,0 +1,25 @@
+import logging
+from pycloudlib.oci.instance import OciInstance
+from pycloudlib.oci.cloud import OCI
+
+logger = logging.getLogger(__name__)
+
+def test_cluster_launch():
+    with OCI(
+        "pycl-oracle-test-cluster-integration-test"
+    ) as cloud:
+        instances = cloud.create_compute_cluster(
+            image_id=cloud.released_image("noble"),
+            instance_count=2,
+        )
+        assert len(instances) == 2
+        for instance in instances:
+            logger.info(f"Instance {instance.instance_id} launched at {instance.ip}")
+            assert instance.ip
+            assert instance.private_ip
+            assert instance.private_ip not in [i.private_ip for i in instances if i != instance]
+            assert instance.execute("true").ok
+            rdma_link_show = instance.execute("rdma link show")
+            logger.info(f"rdma link show: {rdma_link_show}")
+            assert rdma_link_show.ok
+            assert rdma_link_show.stdout


### PR DESCRIPTION
This PR adds a new node-to-node test using ucmatose as well as a single-node, two-process test with ucx_perftest.
It also fixes a couple issues I found with the original rping/vnic test implementations.
These tests do NOT work with the standard Noble cloud image for OCI, since it does not come with the MOFED stack preinstalled. If you'd like to see them pass, you need to select an image for which ucmatose, ucx_perftest, rping, and all required MOFED/DOCA-OFED kernel modules are correctly installed and configured.